### PR TITLE
Jaehwan

### DIFF
--- a/baekjoon/1021. 회전하는 큐/재환/Prob1021.java
+++ b/baekjoon/1021. 회전하는 큐/재환/Prob1021.java
@@ -1,0 +1,65 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Prob1021 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st1 = new StringTokenizer(br.readLine());
+
+        int size = Integer.parseInt(st1.nextToken());                   // 큐의 크기 : size(N)
+        int count = Integer.parseInt(st1.nextToken());                  // 뽑아내려고 하는 수의 개수 : M(count)
+
+        StringTokenizer st2 = new StringTokenizer(br.readLine());
+        int[] idx = new int[count];
+
+        for (int i = 0; i < count; i++) {
+            idx[i] = Integer.parseInt(st2.nextToken()) - 1;
+        }
+
+        Queue<Integer> intQue = new LinkedList<>();
+        for (int i = 0; i < size; i++) {
+            intQue.add(i);
+        }
+
+        boolean moveLeft;
+        int num = 0;
+
+        for (int i = 0; i < count; i++) {
+            while (intQue.element() != idx[i]) {
+                int index = getIdx(intQue, idx[i]);
+                moveLeft = (intQue.size() - index) > index;
+
+                if (moveLeft) {
+                    intQue.add(intQue.remove());
+                    num++;
+                } else {
+                    for (int j = 0; j < intQue.size() - 1; j++) {
+                        intQue.add(intQue.remove());
+                    }
+                    num++;
+                }
+            }
+            intQue.remove();
+        }
+        System.out.println(num);
+    }
+
+    static int getIdx(Queue<Integer> intQue, int n) {
+        Iterator<Integer> it = intQue.iterator();
+        int idx = 0;
+
+        while(it.hasNext()) {
+            if (it.next() == n) {
+                return idx;
+            } else {
+                idx++;
+            }
+        }
+        return idx;
+    }
+}

--- a/baekjoon/1918. 후위 표기식/재환/Prob9012.java
+++ b/baekjoon/1918. 후위 표기식/재환/Prob9012.java
@@ -1,0 +1,47 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.Buffer;
+import java.util.Stack;
+
+public class Prob9012 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        char[][] charArr = new char[n][];
+
+        for (int i = 0; i < n; i++) {
+            String str = br.readLine();
+            charArr[i] = str.toCharArray();
+        }
+
+        for (int i = 0; i < n; i++) {
+            boolean TF = false;
+            Stack<Character> stk = new Stack<>();
+
+            for (int j = 0; j < charArr[i].length; j++) {
+                switch (charArr[i][j]) {
+                    case '(':
+                        stk.push(charArr[i][j]);
+                        break;
+                    case ')':
+                        if (stk.empty()) {
+                            TF = true;
+                            break;
+                        }
+                        stk.pop();
+                        break;
+                }
+                if (TF) {
+                    break;
+                }
+            }
+            if (stk.empty() && !TF) {
+                System.out.println("YES");
+            } else {
+                System.out.println("NO");
+            }
+        }
+    }
+}

--- a/baekjoon/1966. 프린터 큐/재환/Prob1966.java
+++ b/baekjoon/1966. 프린터 큐/재환/Prob1966.java
@@ -1,0 +1,91 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Prob1966 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int testNum = Integer.parseInt(br.readLine());                                  // 테스트 횟수
+        int[] printNum = new int[testNum];
+
+        for (int i = 0; i < testNum; i++) {                                             // 테스트 시작
+            StringTokenizer st1 = new StringTokenizer(br.readLine());
+            int docsCount = Integer.parseInt(st1.nextToken());
+            int targetIdx = Integer.parseInt(st1.nextToken());
+            int targetPriority = -1;
+
+            StringTokenizer st2 = new StringTokenizer(br.readLine());
+            Queue<Integer> printQue = new LinkedList<>();
+            int ele;
+
+            for (int j = 0; j < docsCount; j++) {
+                ele = Integer.parseInt(st2.nextToken());
+                printQue.add(ele);
+                if (j == targetIdx) {
+                    targetPriority = ele;
+                }
+            }
+
+            boolean printTarget = false;
+            int print = 0;
+
+            // printQue의 max priority 값이 target document의 priority 값보다 큰 경우
+            // target document는 출력되지 않고 printQue를 돌 것이다.
+            while (getMax(printQue) > targetPriority) {
+
+                // head 요소가 max priority 값보다 큰 경우
+                // head 요소 제거 + 프린트 횟수 증가 + targetIdx 감소(-1)
+                if (printQue.element() > getMax(printQue)) {
+                    printQue.remove();
+                    print++;
+                }
+                // head 요소가 target document의 priority 값보다 작거나 같은 경우
+                // rear 요소에 head 요소 추가 + targetIdx 감소(-1)
+                else {
+                    printQue.add(printQue.remove());
+                }
+
+                // targetIdx 감소(-1)
+                // targetIdx가 음수가 되면 큐의 가장 마지막 index를 부여
+                if (--targetIdx < 0) {
+                    targetIdx = printQue.size() - 1;
+                }
+            }   // while문을 마치면 target document의 priority와 max priority 일치
+
+            for (int j = 0; j <= targetIdx; j++) {
+                if (printQue.element() == getMax(printQue)) {
+                    printQue.remove();
+                    print++;
+                } else {
+                    printQue.add(printQue.remove());
+                }
+            }   // for 문 가장 마지막에 target이 print 된다.
+
+            printNum[i] = print;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int num : printNum) {
+            sb.append(num).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    static int getMax(Queue<Integer> intQue) {
+        Iterator<Integer> it = intQue.iterator();
+        int max = 0;
+        int priority;
+
+        while (it.hasNext()) {
+            priority = it.next();
+            if (max < priority) {
+                max = priority;
+            }
+        }
+        return max;
+    }
+}

--- a/baekjoon/1966. 프린터 큐/재환/Prob1966.java
+++ b/baekjoon/1966. 프린터 큐/재환/Prob1966.java
@@ -30,16 +30,15 @@ public class Prob1966 {
                 }
             }
 
-            boolean printTarget = false;
             int print = 0;
 
             // printQue의 max priority 값이 target document의 priority 값보다 큰 경우
             // target document는 출력되지 않고 printQue를 돌 것이다.
-            while (getMax(printQue) > targetPriority) {
+            while (!chkPriority(printQue, targetPriority)) {
 
                 // head 요소가 max priority 값보다 큰 경우
                 // head 요소 제거 + 프린트 횟수 증가 + targetIdx 감소(-1)
-                if (printQue.element() > getMax(printQue)) {
+                if (chkPriority(printQue, printQue.element())) {
                     printQue.remove();
                     print++;
                 }
@@ -57,7 +56,7 @@ public class Prob1966 {
             }   // while문을 마치면 target document의 priority와 max priority 일치
 
             for (int j = 0; j <= targetIdx; j++) {
-                if (printQue.element() == getMax(printQue)) {
+                if (chkPriority(printQue, printQue.element())) {
                     printQue.remove();
                     print++;
                 } else {
@@ -75,7 +74,7 @@ public class Prob1966 {
         System.out.println(sb);
     }
 
-    static int getMax(Queue<Integer> intQue) {
+/*    static int getMax(Queue<Integer> intQue) {
         Iterator<Integer> it = intQue.iterator();
         int max = 0;
         int priority;
@@ -87,5 +86,18 @@ public class Prob1966 {
             }
         }
         return max;
+    }*/
+
+    static boolean chkPriority(Queue<Integer> intQue, int priority) {
+        Iterator<Integer> it = intQue.iterator();
+        boolean chk = true;
+
+        while(it.hasNext()) {
+            if (priority < it.next()) {
+                chk = false;
+                break;
+            }
+        }
+        return chk;
     }
 }

--- a/baekjoon/2164. 카드2/재환/Prob2164.java
+++ b/baekjoon/2164. 카드2/재환/Prob2164.java
@@ -1,0 +1,28 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class Prob2164 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int num = Integer.parseInt(br.readLine());     // 정수 N
+        Queue<Integer> cardQue = new LinkedList<>();
+
+        for (int i = 1; i <= num; i++) {
+            cardQue.add(i);
+        }
+
+        while (cardQue.size() != 1) {
+            cardQue.remove();
+            if (cardQue.size() == 1) {
+                System.out.println(cardQue.element());
+                return;
+            }
+            cardQue.add(cardQue.remove());
+        }
+
+        System.out.println(cardQue.element());
+    }
+}


### PR DESCRIPTION
Prob1966. 프린터 큐 구현
- 기존 getMax 메소드에서는 큐의 모든 요소를 점검
- getMax 메소드가 아닌 chkPriority 메소드를 사용하여
   peek 요소보다 높은 우선순위를 발견시
   break  하여 시간 초과 문제 해결